### PR TITLE
feat[button]: error 버튼 구현

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -713,6 +713,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
+  m_IsActive: 0
 --- !u!82 &129892456
 AudioSource:
   m_ObjectHideFlags: 0
@@ -8017,6 +8018,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: SounManager, Assembly-CSharp
         m_MethodName: PlayClickSound
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 781942577}
+        m_TargetAssemblyTypeName: ButtonManager, Assembly-CSharp
+        m_MethodName: ErrorButton
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scripts/ButtonManager.cs
+++ b/Assets/Scripts/ButtonManager.cs
@@ -45,7 +45,7 @@ public class ButtonManager : MonoBehaviour
 
         Debug.Log("Stop!"); //일시정지
 
-         if (turtleManager != null)
+        if (turtleManager != null)
             turtleManager.PrintError("Stop 버튼이 눌렸습니다");
         else if (TurtleManager.instance != null)
             TurtleManager.instance.PrintError("Stop 버튼이 눌렸습니다");
@@ -309,11 +309,20 @@ public class ButtonManager : MonoBehaviour
     }*/
 
     //Error!!
-    public void ErrorButton()
+    public void ErrorButton(string errorType)
     {
+        if (lastClickedButton == "Error")
+        {
+            Debug.Log("Error 버튼 연속 클릭 방지됨");
+            return;
+        }
 
-        Debug.Log("Something Wrong!"); //오류 알려주기
+        lastClickedButton = "Error";
+
+        Debug.Log("Error 버튼이 눌렸습니다.");
+        turtleManager.OnErrorButtonClicked();
     }
+
 
 
     //Exit!!


### PR DESCRIPTION
- **TurtleManager**에서 마지막 에러 메시지를 저장하도록 로직 추가
- 에러 버튼 클릭 시 `lastFriendlyMessage`를 콘솔 및 터미널에 출력하도록 구현
- 버튼 클릭에서 별도의 에러 타입 파라미터 불필요
- 기존 `PrintError`는 `errorType`을 받아 에러 메시지를 저장하고 표시